### PR TITLE
[BS-899] Update installation instructions to reference actual gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,13 @@ This gem adds a Ruby integration for Cortex's API.
 
 ## Installation
 
-TODO: Replace `UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG` with your gem name right after releasing it to RubyGems.org. Please do not do it earlier due to security reasons. Alternatively, replace this section with instructions to install your gem from git if you don't plan to release to RubyGems.org.
-
 Install the gem and add to the application's Gemfile by executing:
 
-    $ bundle add UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+    $ bundle add cortex_app
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 
-    $ gem install UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+    $ gem install cortex_app
 
 ## Usage
 


### PR DESCRIPTION
## Purpose
Update installation instructions to reference actual gem

## Context
Rubygems.org recommends doing this post-release due to security concerns, i.e. someone might hijack your gem name and publish malicious code.

NOTE: Since this does not affect functionality, I don't plan to cut a new release of the gem.